### PR TITLE
Feature infinite scroll

### DIFF
--- a/CryptocurrencyTradingApp.xcodeproj/project.pbxproj
+++ b/CryptocurrencyTradingApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		D47D009F2797A0EA00E8E305 /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D009E2797A0EA00E8E305 /* UIStackView+Extension.swift */; };
 		D47D00A32797A1A600E8E305 /* Ticker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D00A22797A1A600E8E305 /* Ticker.swift */; };
 		D47D00A52797A70400E8E305 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47D00A42797A70400E8E305 /* String+Extension.swift */; };
+		D48878D127D5D58600C63FE4 /* NetworkState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48878D027D5D58600C63FE4 /* NetworkState.swift */; };
 		D4AFEB2B27A01FC300011251 /* BithumbRestAPITransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFEB2A27A01FC300011251 /* BithumbRestAPITransaction.swift */; };
 		D4AFEB2D27A0350800011251 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFEB2C27A0350800011251 /* Transaction.swift */; };
 		D4AFEB2F27A03FB300011251 /* MainListCoinViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AFEB2E27A03FB300011251 /* MainListCoinViewModel.swift */; };
@@ -54,7 +55,6 @@
 		D4C9F90627B65DEE00EDF156 /* UpbitWebSocketParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F90527B65DEE00EDF156 /* UpbitWebSocketParameter.swift */; };
 		D4C9F90827B65E0000EDF156 /* WebSocketParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F90727B65E0000EDF156 /* WebSocketParameter.swift */; };
 		D4C9F90A27BA5A6C00EDF156 /* DateFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F90927BA5A6C00EDF156 /* DateFormat.swift */; };
-		D4C9F91127BB640600EDF156 /* SwiftJWT in Frameworks */ = {isa = PBXBuildFile; productRef = D4C9F91027BB640600EDF156 /* SwiftJWT */; };
 		D4C9F91327BB8B0E00EDF156 /* JWTGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F91227BB8B0E00EDF156 /* JWTGenerator.swift */; };
 		D4C9F91527BB8B5D00EDF156 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F91427BB8B5D00EDF156 /* Data+Extension.swift */; };
 		D4C9F91727BB8B7700EDF156 /* JWTModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C9F91627BB8B7700EDF156 /* JWTModel.swift */; };
@@ -127,6 +127,7 @@
 		D47D009E2797A0EA00E8E305 /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		D47D00A22797A1A600E8E305 /* Ticker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ticker.swift; sourceTree = "<group>"; };
 		D47D00A42797A70400E8E305 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		D48878D027D5D58600C63FE4 /* NetworkState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkState.swift; sourceTree = "<group>"; };
 		D4AFEB2A27A01FC300011251 /* BithumbRestAPITransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BithumbRestAPITransaction.swift; sourceTree = "<group>"; };
 		D4AFEB2C27A0350800011251 /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		D4AFEB2E27A03FB300011251 /* MainListCoinViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainListCoinViewModel.swift; sourceTree = "<group>"; };
@@ -368,6 +369,7 @@
 				E605E0B227B654F6002B84F1 /* PaymentCurrency.swift */,
 				D4C9F90327B65BCE00EDF156 /* WebSocketURL.swift */,
 				D4C9F90927BA5A6C00EDF156 /* DateFormat.swift */,
+				D48878D027D5D58600C63FE4 /* NetworkState.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -612,6 +614,7 @@
 				E6A8694527A29F1800D568B3 /* CandleStickCoreDataEntity.swift in Sources */,
 				D4B40E1827A5570200EDA235 /* BithumbRestAPIAssetStatus.swift in Sources */,
 				E6BDEFAF27A3E31A00018967 /* CandleData30M+CoreDataProperties.swift in Sources */,
+				D48878D127D5D58600C63FE4 /* NetworkState.swift in Sources */,
 				D4B40E3227A65AA000EDA235 /* MiniChartView.swift in Sources */,
 				E64BFA272795616600BC17A1 /* WebSocketManager.swift in Sources */,
 				E6197F9327A6AC3100EF207B /* DetailCoinViewController.swift in Sources */,

--- a/CryptocurrencyTradingApp/Controller/MainListViewController.swift
+++ b/CryptocurrencyTradingApp/Controller/MainListViewController.swift
@@ -61,10 +61,6 @@ class MainListViewController: UIViewController {
                                                name: .webSocketTransactionsNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(updateDataSource),
-                                               name: .webSocketTicker24HNotification,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
                                                selector: #selector(makeSnapshot),
                                                name: .updateSortNotification,
                                                object: nil)
@@ -73,7 +69,6 @@ class MainListViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         viewModel.closeWebSocket()
         NotificationCenter.default.removeObserver(self, name: .webSocketTransactionsNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .webSocketTicker24HNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: .updateSortNotification, object: nil)
     }
     

--- a/CryptocurrencyTradingApp/Controller/TransactionsViewController.swift
+++ b/CryptocurrencyTradingApp/Controller/TransactionsViewController.swift
@@ -25,7 +25,7 @@ class TransactionsViewController: UIViewController {
         menuControl.layer.masksToBounds = true
         return menuControl
     }()
-    
+
     init(_ market: UpbitMarket) {
         self.market = market
         self.viewModel = TransactionsViewModel(market)

--- a/CryptocurrencyTradingApp/Controller/TransactionsViewController.swift
+++ b/CryptocurrencyTradingApp/Controller/TransactionsViewController.swift
@@ -26,7 +26,6 @@ class TransactionsViewController: UIViewController {
         return menuControl
     }()
     
-
     init(_ market: UpbitMarket) {
         self.market = market
         self.viewModel = TransactionsViewModel(market)
@@ -92,6 +91,7 @@ class TransactionsViewController: UIViewController {
     }
 }
 
+// MARK: UISegmentedControl
 extension TransactionsViewController {
     private func menuControlAutolayout() {
         view.addSubview(menuControl)
@@ -120,6 +120,7 @@ extension TransactionsViewController {
     }
 }
 
+// MARK: UITableView
 extension TransactionsViewController {
 
     @objc private func makeTimeSnapshot() {
@@ -212,5 +213,21 @@ extension TransactionsViewController: UITableViewDelegate {
         header.configure(isTimeCell: isTime, symbol: market.symbol)
         
         return header
+    }
+}
+
+// MARK: Infinite Scroll
+extension TransactionsViewController {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let scrollViewHeight = scrollView.contentSize.height
+        let screenHeight = scrollView.contentOffset.y
+        let remainingBottomContentHeight = scrollViewHeight - screenHeight
+
+        let frameHeight = scrollView.frame.size.height
+        if remainingBottomContentHeight < frameHeight {
+            dayTableView.isHidden
+            ? viewModel.loadMoreTimeTransactions()
+            : viewModel.loadMoreDayTransactions()
+        }
     }
 }

--- a/CryptocurrencyTradingApp/Enum/NetworkState.swift
+++ b/CryptocurrencyTradingApp/Enum/NetworkState.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkState.swift
+//  CryptocurrencyTradingApp
+//
+//  Created by 홍정아 on 2022/03/07.
+//
+
+import Foundation
+
+enum NetworkState {
+    case idle
+    case isLoading
+}

--- a/CryptocurrencyTradingApp/ErrorCase/NetworkError.swift
+++ b/CryptocurrencyTradingApp/ErrorCase/NetworkError.swift
@@ -12,6 +12,7 @@ enum NetworkError: LocalizedError {
     case invalidData
     case invalidURL
     case unverifiedCoin
+    case overlappingRequest
     
     var errorDescription: String? {
         switch self {
@@ -23,6 +24,8 @@ enum NetworkError: LocalizedError {
             return "유효한 URL이 아닙니다"
         case .unverifiedCoin:
             return "확인되지 않은 코인입니다"
+        case .overlappingRequest:
+            return "cancelled"
         }
     }
 }

--- a/CryptocurrencyTradingApp/Extension/String+Extension.swift
+++ b/CryptocurrencyTradingApp/Extension/String+Extension.swift
@@ -97,4 +97,10 @@ extension String {
         
         return formatted
     }
+    
+    func dropLast(_ count: Int) -> String {
+        let start = self.startIndex
+        let end = self.index(self.endIndex, offsetBy: -1 * count)
+        return String(self[start..<end])
+    }
 }

--- a/CryptocurrencyTradingApp/Model/Upbit/UpbitCandleStick.swift
+++ b/CryptocurrencyTradingApp/Model/Upbit/UpbitCandleStick.swift
@@ -16,6 +16,7 @@ struct UpbitCandleStick: Decodable {
     let tradeVolume: Double
     let prevPrice: Double?
     let timestamp: Double
+    let dateKST: String
     
     enum CodingKeys: String, CodingKey {
         case market, timestamp
@@ -25,5 +26,6 @@ struct UpbitCandleStick: Decodable {
         case highPrice = "high_price"
         case tradeVolume = "candle_acc_trade_volume"
         case prevPrice = "prev_closing_price"
+        case dateKST = "candle_date_time_kst"
     }
 }

--- a/CryptocurrencyTradingApp/Model/Upbit/UpbitTrade.swift
+++ b/CryptocurrencyTradingApp/Model/Upbit/UpbitTrade.swift
@@ -9,14 +9,18 @@ import Foundation
 
 struct UpbitTrade: Decodable {
     let price: Double
+    let prevPrice: Double
     let quantity: Double
-    let date: Double
+    let timestamp: Double
     let type: String
+    let cursor: Double
     
     enum CodingKeys: String, CodingKey {
         case price = "trade_price"
+        case prevPrice = "prev_closing_price"
         case quantity = "trade_volume"
-        case date = "timestamp"
+        case timestamp
         case type = "ask_bid"
+        case cursor = "sequential_id"
     }
 }

--- a/CryptocurrencyTradingApp/Services/NetworkLayer/NetworkModule.swift
+++ b/CryptocurrencyTradingApp/Services/NetworkLayer/NetworkModule.swift
@@ -9,22 +9,20 @@ import Foundation
 
 class NetworkModule: Networkable {
     private let rangeOfSuccessState = 200...299
-    private var dataTask: [URLSessionDataTask] = []
+    private var networkStates: [URLRequest: NetworkState] = [:]
     
     func runDataTask<T: Decodable>(request: URLRequest,
                                    completionHandler: @escaping (Result<T, Error>) -> Void) {
         
-        dataTask.enumerated().forEach { (index, task) in
-            if let originalRequest = task.originalRequest,
-               originalRequest == request {
-                task.cancel()
-                if dataTask.count > index {
-                    dataTask.remove(at: index)
-                }
+        if let networkState = networkStates[request], networkState == .isLoading {
+            DispatchQueue.main.async {
+                completionHandler(.failure(NetworkError.overlappingRequest))
             }
+            return
         }
+        networkStates[request] = .isLoading
         
-        let task = URLSession.shared.dataTask(with: request) { [self] (data, response, error) in
+        URLSession.shared.dataTask(with: request) { [self] (data, response, error) in
             if let error = error {
                 DispatchQueue.main.async {
                     completionHandler(.failure(error))
@@ -47,13 +45,6 @@ class NetworkModule: Networkable {
                 return
             }
             
-            dataTask.enumerated().forEach { (index, task) in
-                if let originalRequest = task.originalRequest,
-                   originalRequest == request {
-                    dataTask.remove(at: index)
-                }
-            }
-            
             do {
                 let parsedData = try JSONDecoder().decode(T.self, from: data)
                 DispatchQueue.main.async {
@@ -64,9 +55,7 @@ class NetworkModule: Networkable {
                     completionHandler(.failure(error))
                 }
             }
-        }
-        
-        task.resume()
-        dataTask.append(task)
+            networkStates.removeValue(forKey: request)
+        }.resume()
     }
 }

--- a/CryptocurrencyTradingApp/ViewModel/DayTransactionViewModel.swift
+++ b/CryptocurrencyTradingApp/ViewModel/DayTransactionViewModel.swift
@@ -15,7 +15,7 @@ class DayTransactionViewModel:TransactionViewModelType {
     }
     
     var date: String {
-        dayTransaction.date.toDate()
+        dayTransaction.date
     }
     
     var closePrice: String {

--- a/CryptocurrencyTradingApp/ViewModel/MainListCoinsViewModel.swift
+++ b/CryptocurrencyTradingApp/ViewModel/MainListCoinsViewModel.swift
@@ -9,12 +9,12 @@ import UIKit
 
 class MainListCoinsViewModel {
     let markets: [UpbitMarket]
-    private var mainListCoins: [Ticker] = [] {
-        didSet {
-            filtered = mainListCoins.filter { existsInFiltered($0) }
-            favorites = filtered.filter { favoriteSymbols.contains( $0.symbol.lowercased() ) }
-        }
-    }
+    private var mainListCoins: [Ticker] = []
+//        didSet {
+//            filtered = mainListCoins.filter { existsInFiltered($0) }
+//            favorites = filtered.filter { favoriteSymbols.contains( $0.symbol.lowercased() ) }
+//        }
+//    }
     
     private var favoriteSymbols: [String] {
         return UserDefaults.standard.array(forKey: "favorite") as? [String] ?? []
@@ -149,6 +149,8 @@ extension MainListCoinsViewModel {
                 if newPrice == oldPrice { return }
                 
                 mainListCoins[index].currentPrice = newPrice
+                filtered = mainListCoins.filter { existsInFiltered($0) }
+                favorites = filtered.filter { favoriteSymbols.contains( $0.symbol.lowercased() ) }
                 let userInfo = userInfo(at: index, hasRisen: newPrice.toDouble() > oldPrice.toDouble())
                 NotificationCenter.default.post(name: .webSocketTransactionsNotification,
                                                 object: "currentPrice",
@@ -168,6 +170,8 @@ extension MainListCoinsViewModel {
                 mainListCoins[index].tradeValue = ticker.accumulatedTradeValue.description
                 mainListCoins[index].fluctuationRate = (ticker.fluctuationRate * 100).description
                 mainListCoins[index].fluctuationAmount = ticker.fluctuationAmount.description
+                filtered = mainListCoins.filter { existsInFiltered($0) }
+                favorites = filtered.filter { favoriteSymbols.contains( $0.symbol.lowercased() ) }
             }
         }
     }

--- a/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
+++ b/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
@@ -65,7 +65,9 @@ extension TransactionsViewModel {
                 self.timeCursor = parsedData.last?.cursor.description.lose(from: ".")
                 NotificationCenter.default.post(name: .restAPITransactionsNotification, object: nil)
             case .failure(let error):
-                assertionFailure(error.localizedDescription)
+                if error.localizedDescription != "cancelled" {
+                    assertionFailure(error.localizedDescription)
+                }
             }
         }
     }
@@ -86,7 +88,7 @@ extension TransactionsViewModel {
         let route = UpbitRoute.candles(.twentyFourHour)
         networkManager.request(with: route,
                                queryItems: route.candlesQueryItems(coin: market,
-                                                                   lastDate: dayLastDate,
+                                                                   lastDate: dayLastDate?.replacingOccurrences(of: "T", with: " "),
                                                                    candleCount: 50),
                                requestType: .request)
         { (parsedResult: Result<[UpbitCandleStick], Error>) in
@@ -105,7 +107,9 @@ extension TransactionsViewModel {
             case .failure(NetworkError.unverifiedCoin):
                 print(NetworkError.unverifiedCoin.localizedDescription)
             case .failure(let error):
-                assertionFailure(error.localizedDescription)
+                if error.localizedDescription != "cancelled" {
+                    assertionFailure(error.localizedDescription)
+                }
             }
         }
     }
@@ -130,7 +134,9 @@ extension TransactionsViewModel {
             case .failure(NetworkError.unverifiedCoin):
                 print(NetworkError.unverifiedCoin.localizedDescription)
             case .failure(let error):
-                assertionFailure(error.localizedDescription)
+                if error.localizedDescription != "cancelled" {
+                    assertionFailure(error.localizedDescription)
+                }
             }
         }
     }

--- a/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
+++ b/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
@@ -59,7 +59,7 @@ extension TransactionsViewModel {
                                 price: $0.price.description,
                                 quantity: $0.quantity.description,
                                 amount: ($0.price * $0.quantity).description,
-                                date: $0.date.description,
+                                date: $0.timestamp.description,
                                 upDown: nil)
                 }.sorted { $0.date > $1.date }
                 self.timeCursor = parsedData.last?.cursor.description.lose(from: ".")
@@ -98,7 +98,7 @@ extension TransactionsViewModel {
                     Transaction(price: $0.closingPrice.description,
                                 prevPrice: $0.prevPrice?.description ?? .zero,
                                 quantity: $0.tradeVolume.description,
-                                date: $0.timestamp.description)
+                                date: $0.dateKST.replacingOccurrences(of: "T", with: " ").dropLast(3))
                 }
                 self.dayLastDate = parsedData.last?.dateKST
                 NotificationCenter.default.post(name: .candlestickNotification, object: nil)

--- a/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
+++ b/CryptocurrencyTradingApp/ViewModel/TransactionsViewModel.swift
@@ -107,9 +107,11 @@ extension TransactionsViewModel {
             case .failure(NetworkError.unverifiedCoin):
                 print(NetworkError.unverifiedCoin.localizedDescription)
             case .failure(let error):
+//                assertionFailure(error.localizedDescription)
                 if error.localizedDescription != "cancelled" {
                     assertionFailure(error.localizedDescription)
                 }
+//                print(error.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
### 체결내역 시간별/일별 데이터에 무한 스크롤 적용
- scrollViewDidScroll() 활용
  - 데이터를 여러개 한번에 받기 때문에 prefetch보다는 현재 방법이 낫다고 판단
  - prefetch는 미리 prefetch할 indexPath마다 다운받는 방식으로 이해했기 때문
- scrollViewDidScroll에 의해 네트워크 요청이 업비트 API의 제한 횟수를 초과하는 문제 해결
  - 동일한 request의 경우 이후 발생하는 중복 요청을 모두 무시하도록 딕셔너리에 request마다 통신 상태 저장